### PR TITLE
Fix/result xml reading

### DIFF
--- a/src/main/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapper.java
+++ b/src/main/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapper.java
@@ -97,15 +97,12 @@ public class ChemStationToAllotropeMapper {
         GasChromatographyAggregateDocument document = new GasChromatographyAggregateDocument();
 
         DeviceSystemDocument deviceSystemDocument = new DeviceSystemDocument();
-        deviceSystemDocument.setAssetManagementIdentifier(((Element) chemStationResult.acquisition.instrumentName).getTextContent());
+        deviceSystemDocument.setAssetManagementIdentifier(chemStationResult.getAcquisition().getInstrumentName());
 
         GasChromatographyDocument gasChromatographyDocument = new GasChromatographyDocument();
-        applyValue(gasChromatographyDocument::setAnalyst, chFile.getOperator(),
-                   ((Element) chemStationResult.sampleInformation.operator).getTextContent());
-        applyValue(gasChromatographyDocument::setSubmitter, chFile.getOperator(),
-                   ((Element) chemStationResult.sampleInformation.operator).getTextContent());
-        applyValue(gasChromatographyDocument::setDeviceMethodIdentifier, chFile.getMethod(),
-                   ((Element) chemStationResult.sampleInformation.method).getTextContent());
+        applyValue(gasChromatographyDocument::setAnalyst, chFile.getOperator(), ((Element) chemStationResult.sampleInformation.operator).getTextContent());
+        gasChromatographyDocument.setSubmitter(gasChromatographyDocument.getAnalyst());
+        applyValue(gasChromatographyDocument::setDeviceMethodIdentifier, chFile.getMethod(), chemStationResult.getSampleInformation().getMethod());
 
         ChromatographyColumnDocument chromatographyColumnDocument =
                 columnInformationMapper.readColumnDocumentFromFile(folderPath, acqTxtFilename);
@@ -119,16 +116,14 @@ public class ChemStationToAllotropeMapper {
         gasChromatographyDocument.setDetectorControlAggregateDocument(detectorControlAggregateDocument);
 
         SampleDocument sampleDocument = new SampleDocument();
-        applyValue(sampleDocument::setSampleIdentifier, chFile.getSampleName(),
-                   ((Element) chemStationResult.sampleInformation.sampleName).getTextContent());
-        applyValue(sampleDocument::setWrittenName, chFile.getSampleName(),
-                   ((Element) chemStationResult.sampleInformation.sampleName).getTextContent());
+        applyValue(sampleDocument::setSampleIdentifier, chFile.getSampleName(), chemStationResult.getSampleInformation().getSampleName());
+        sampleDocument.setWrittenName(sampleDocument.getSampleIdentifier());
         sampleDocument.setDescription(((Element) chemStationResult.sampleInformation.sampleInfo).getTextContent());
         gasChromatographyDocument.setSampleDocument(sampleDocument);
 
         InjectionDocument injectionDocument = new InjectionDocument();
         applyValue(injectionDocument::setInjectionTime, getInjectionDateInstant(chFile.getInjectionDateTime()),
-                getInjectionDateInstant(((Element) chemStationResult.sampleInformation.injectionDateTime).getTextContent()));
+                getInjectionDateInstant(chemStationResult.getSampleInformation().getInjectionDateTime()));
         injectionDocument.setInjectionIdentifier(((Element) chemStationResult.sampleInformation.inj).getTextContent());
 
         InjectionVolumeSetting injectionVolumeSetting = new InjectionVolumeSetting();

--- a/src/main/java/fr/ifpen/allotropeconverters/gc/chemstation/PeakMapper.java
+++ b/src/main/java/fr/ifpen/allotropeconverters/gc/chemstation/PeakMapper.java
@@ -15,7 +15,7 @@ public class PeakMapper {
     public Peak mapPeakFromCompound(CompoundType compoundType) {
         Peak peak = new Peak();
         peak.setIdentifier(compoundType.getCompoundID().toString());
-        peak.setWrittenName(compoundType.getName() instanceof Node node ? node.getTextContent() : compoundType.getName().toString());
+        peak.setWrittenName(compoundType.getName());
 
         PeakHeight peakHeight = new PeakHeight();
         peakHeight.setValue(Double.parseDouble(compoundType.getHeight().getContent()));

--- a/src/main/resources/EXPORT.XSD
+++ b/src/main/resources/EXPORT.XSD
@@ -74,7 +74,7 @@
 	<xs:complexType name="AcquisitionType">
 		<xs:sequence>
 			<xs:element name="Version"/>
-			<xs:element name="InstrumentName"/>
+			<xs:element name="InstrumentName" type="xs:string"/>
 			<xs:element name="MethodPath"/>
 			<xs:element name="InjectionTime"/>
 			<xs:element name="MethodLastModifiedTime"/>
@@ -115,17 +115,17 @@
 			<xs:element name="SeqLine"/>
 			<xs:element name="Location"/>
 			<xs:element name="Inj"/>
-			<xs:element name="Method"/>
+			<xs:element name="Method" type="xs:string"/>
 			<xs:element name="Operator"/>
-			<xs:element name="InjectionDateTime"/>
-			<xs:element name="SampleName"/>
+			<xs:element name="InjectionDateTime" type="xs:string"/>
+			<xs:element name="SampleName" type="xs:string"/>
 			<xs:element name="SampleInfo"/>
 			<xs:element name="IstdNum"/>
 			<xs:element name="InternalStandardAmount"/>
 			<xs:element name="SampleAmount"/>
 			<xs:element name="Multiplier"/>
 			<xs:element name="MethodInfo"/>
-			<xs:element name="CalMethod"/>
+			<xs:element name="CalMethod" type="xs:string"/>
 			<xs:element name="ResModDateTime"/>
 			<xs:element name="LimsID" minOccurs="0"/>
 			<xs:element name="LimsKField2" minOccurs="0"/>
@@ -147,17 +147,17 @@
 	<xs:complexType name="SignalType">
 		<xs:sequence>
 			<xs:element name="Title"/>
-			<xs:element name="Description"/>
+			<xs:element name="Description" type="xs:string"/>
 			<xs:element name="Detector"/>
-			<xs:element name="SignalId"/>
+			<xs:element name="SignalId" type="xs:string"/>
 			<xs:element name="Operator"/>
 			<xs:element name="DateTime"/>
 			<xs:element name="DerivOrder"/>
-			<xs:element name="RawdataFile"/>
+			<xs:element name="RawdataFile" type="xs:string"/>
 			<xs:element name="Start"/>
 			<xs:element name="End"/>
-			<xs:element name="XUnits"/>
-			<xs:element name="YUnits"/>
+			<xs:element name="XUnits" type="xs:string"/>
+			<xs:element name="YUnits" type="xs:string"/>
 			<xs:element name="Noise" minOccurs="0">
 				<xs:complexType>
 					<xs:sequence maxOccurs="unbounded">
@@ -183,7 +183,7 @@
 	<xs:complexType name="CompoundType">
 		<xs:sequence>
 			<xs:element name="CompoundID" type="xs:integer" minOccurs="0"/>
-			<xs:element name="SignalDesc"/>
+			<xs:element name="SignalDesc" type="xs:string"/>
 			<xs:element name="PeakType" type="xs:anySimpleType"/>
 			<xs:element name="ExpRetTime" type="Value"/>
 			<xs:element name="MeasRetTime" type="Value"/>
@@ -191,7 +191,7 @@
 			<xs:element name="Height" type="Value"/>
 			<xs:element name="Width" type="Value"/>
 			<xs:element name="Symmetry" type="Value"/>
-			<xs:element name="Name"/>
+			<xs:element name="Name" type="xs:string"/>
 			<xs:element name="Amount" type="Value"/>
 			<xs:sequence minOccurs="0">
 				<xs:element name="kPrime" type="Value" nillable="1"/>

--- a/src/test/java/fr/ifpen/allotropeconverters/gc/TestConstants.java
+++ b/src/test/java/fr/ifpen/allotropeconverters/gc/TestConstants.java
@@ -11,6 +11,7 @@ public class TestConstants {
 
     public static final Path RESOURCE_V_179_D_FOLDER = Path.of("src/test/resources/V179.D");
     public static final Path RESOURCE_V_179_D_CH_FILE = RESOURCE_V_179_D_FOLDER.resolve("FID1A.ch");
+    public static final Path RESOURCE_V_179_D_XML_RESULT = RESOURCE_V_179_D_FOLDER.resolve("Result.xml");
 
     public static final Path RESOURCE_V_181_D_FOLDER = Path.of("src/test/resources/V181.D");
     public static final Path RESOURCE_V_181_D_CH_FILE = RESOURCE_V_181_D_FOLDER.resolve("V181.ch");

--- a/src/test/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapperTests.java
+++ b/src/test/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapperTests.java
@@ -102,4 +102,11 @@ class ChemStationToAllotropeMapperTests {
         GasChromatographyTabularEmbedSchema embedSchema = mapper.fromChFile(TestConstants.RESOURCE_V_179_D_CH_FILE);
         assertV179Schema(embedSchema, false);
     }
+
+    @Test
+    void testParseXmlResult() throws JAXBException {
+        ChemStationResult chemStationResult = ChemStationToAllotropeMapper.parseXmlResult(TestConstants.RESOURCE_V_179_D_XML_RESULT);
+        Assertions.assertThat(chemStationResult.getSampleInformation().getSampleName()).isEqualTo("23-03137-2");
+        Assertions.assertThat(chemStationResult.getAcquisition().getInjectionTime()).isEqualTo("11:24:28");
+    }
 }

--- a/src/test/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapperTests.java
+++ b/src/test/java/fr/ifpen/allotropeconverters/gc/chemstation/ChemStationToAllotropeMapperTests.java
@@ -106,7 +106,7 @@ class ChemStationToAllotropeMapperTests {
     @Test
     void testParseXmlResult() throws JAXBException {
         ChemStationResult chemStationResult = ChemStationToAllotropeMapper.parseXmlResult(TestConstants.RESOURCE_V_179_D_XML_RESULT);
-        Assertions.assertThat(chemStationResult.getSampleInformation().getSampleName()).isEqualTo("23-03137-2");
-        Assertions.assertThat(chemStationResult.getAcquisition().getInjectionTime()).isEqualTo("11:24:28");
+        Assertions.assertThat(chemStationResult.getSampleInformation().getSampleName()).isEqualTo("22-00465-1");
+        Assertions.assertThat(chemStationResult.getSampleInformation().getInjectionDateTime()).isEqualTo("12-May-22, 11:24:28");
     }
 }


### PR DESCRIPTION
La récupération du nom d'échantillon ou de la date d'injection n'était vraiment pas possible:

<img width="456" height="150" alt="image" src="https://github.com/user-attachments/assets/bba16025-3e31-433c-84b3-ac6bda35071c" />

Suggestion de correction en reprenant l'export.xsd que j'utilise sur un autre projet (pour en discuter)